### PR TITLE
Enable basic component testings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,11 @@ jobs:
     steps:
       - name: Add repository
         run: |
-          wget -qO- https://imola.armbian.com/apt/armbian.key | gpg --dearmor | sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] https://armbian.github.io/configurator stable main" | sudo tee /etc/apt/sources.list.d/armbian-development.list > /dev/null
-          apt update
+          sudo wget -qO- https://imola.armbian.com/apt/armbian.key | \
+          gpg --dearmor | sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
+          sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] \
+          https://armbian.github.io/configurator stable main" \
+          | sudo tee /etc/apt/sources.list.d/armbian-development.list > /dev/null
+          sudo apt update
           sudo apt-get -y install configurator
           

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,12 @@ on:
       - completed
 
 jobs:
-  test:
+  install:
+    name: "Install configurator"
     runs-on: ubuntu-latest
 
     steps:
-      - name: Add repository
+      - name: "Add repository"
         run: |
           sudo wget -qO- https://imola.armbian.com/apt/armbian.key | \
           gpg --dearmor | sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
@@ -21,3 +22,11 @@ jobs:
           sudo apt update
           sudo apt-get -y install configurator
           
+  run:
+    name: "Run configurator commands"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Run tests"
+        run: |
+          echo "Hello world"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,14 @@
+name: Unit testings
+
+on:
+  workflow_run:
+    workflows: ["Build debian package"]
+    types:
+      - completed
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,14 @@ on:
       - completed
 
 jobs:
-  notify:
+  test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Add repository
+        run: |
+          wget -qO- https://imola.armbian.com/apt/armbian.key | gpg --dearmor | sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] https://armbian.github.io/configurator stable main" | sudo tee /etc/apt/sources.list.d/armbian-development.list > /dev/null
+          apt update
+          sudo apt-get -y install configurator
+          

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ on:
       - completed
 
 jobs:
-  install:
-    name: "Install configurator"
+  test:
+    name: "Testing configurator"
     runs-on: ubuntu-latest
 
     steps:
@@ -21,12 +21,6 @@ jobs:
           | sudo tee /etc/apt/sources.list.d/armbian-development.list > /dev/null
           sudo apt update
           sudo apt-get -y install configurator
-          
-  run:
-    name: "Run configurator commands"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Run tests"
+      - name: "Run configurator commands"
         run: |
           echo "Hello world"


### PR DESCRIPTION
Covering install from repository after packages is being made. Further testing not enabled yet since we don't have a completely working system yet.